### PR TITLE
fix: doesn't show 0 if there's no data for salary

### DIFF
--- a/components/Company/Cover.vue
+++ b/components/Company/Cover.vue
@@ -55,9 +55,9 @@
           <span>میانگین حقوق ماهانه</span>
           <div class="amount layout-h layout-center">
             <strong class="ml-5">
-              {{ company.salary_avg }}
+              {{ averageSalary }}
             </strong>
-            <span>میلیون</span>
+            <span v-if="company.salary_avg">میلیون</span>
           </div>
         </div>
         <div class="rate layout-h layout-center mt-20 ltr">
@@ -115,6 +115,13 @@ export default {
       return this.company.cover
         ? this.mediaUrl(this.company.cover)
         : '/images/cover-default.png'
+    },
+    averageSalary() {
+        if (this.company.salary_avg == 0) {
+            return 'نامعلوم'
+        }
+
+        return this.company.salary_avg
     },
   },
   mounted() {


### PR DESCRIPTION
Hi there!

I have made a change to fix a small bug. There are some companies that have no data and in this case we were showing "0 Million"! No company pays "0 Million" to its employees!

Please test the code before merging because I could not clone it for some reasons.

Thank you.