### PR TITLE
Fix template compile error

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -50,8 +50,8 @@ module.exports = {
    ** Global CSS
    */
   css: [
-    '/fonts/vazir/font.css',
-    'fonts/jobguy/style.css',
+    'assets/styles/fonts/vazir/font.css',
+    'assets/styles/fonts/jobguy/style.css',
     'assets/styles/main.scss',
   ],
 


### PR DESCRIPTION
f5aaf160c2aa3c2a14623c253208aed5cef53023 addresses styles files in a wrong way, resulting in an error when compiling template files.
This PR fixes the issue.